### PR TITLE
Fix section headers so BSS is properly linked

### DIFF
--- a/src/binfmt.rs
+++ b/src/binfmt.rs
@@ -90,13 +90,13 @@ pub struct CoffSectionHeader {
 
 impl CoffSectionHeader {
     pub fn from_section(section: &Section, raw_data_offset: u32) -> Self {
-        let name = match section.name {
-            Name::Literal(s) => s,
-            Name::StringTableIndex(idx) => {
-                let mut buf = [0u8; MAX_NAME_LEN];
-                write!(&mut buf[..], "/{idx}").unwrap();
-                buf
-            }
+        // DJGPP seems to ignore the flags, at least for BSS, and instead use the
+        // section header name to determine how to link.
+        let name = *match section.section_type {
+            CoffSectionType::Unknown => b".unknown",
+            CoffSectionType::Text => b".text\0\0\0",
+            CoffSectionType::Data => b".data\0\0\0",
+            CoffSectionType::Bss => b".bss\0\0\0\0",
         };
 
         let raw_data_ptr = if section.size > 0 { raw_data_offset } else { 0 };

--- a/src/binfmt.rs
+++ b/src/binfmt.rs
@@ -122,7 +122,7 @@ impl CoffSectionHeader {
             line_nums_ptr,
             num_relocations,
             num_line_nums,
-            flags: CoffSectionType::Unknown,
+            flags: section.section_type,
         }
     }
 }


### PR DESCRIPTION
I have been experimenting with this tool and it's been working great so far. However, when I added static variables, I found that they weren't being properly zero-initialized. It turned out that DJGPP wasn't linking the BSS sections of the object file, and so pointers to the BSS data were invalid. I made some small changes to the binfmt file that seem to have fixed it. In particular, I store the section type in the header (previously it was always Unknown), and instead of using the section name in the header, I use ".unknown", ".text", ".data", or ".bss", depending on the section type. It seems that DJGPP won't link the BSS section properly unless it's actually exactly named .bss, at least in the header. The section symbol has the full, original name. Keep in mind that I'm no expert at how DJGPP or its COFF implementation works, so this is just a guess I made that happened to work.